### PR TITLE
fix: Suffix to command names to no longer override the default commands.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,7 @@ export const DEFAULT_STATES: WorkflowState[] = [
   // TODO -> DOING -> DONE (checkbox)
   {
     id: generateDefaultId(1),
-    keyword: "TASK",
+    keyword: "TODO",
     color: prettyColors[2], // Deep navy
     hasCheckbox: true,
     checkboxState: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -774,7 +774,7 @@ async function registerSlashCommands(): Promise<void> {
   try {
     // Register a command for each workflow state
     for (const workflow of workflowStates) {
-      await logseq.Editor.registerSlashCommand(workflow.keyword, async () => {
+      await logseq.Editor.registerSlashCommand(`${workflow.keyword} Workflow`, async () => {
         try {
           // Get current block to check for existing workflow macros
           const block = await logseq.Editor.getCurrentBlock();


### PR DESCRIPTION
- Updated the slash command registration to append " Workflow" to the command name, improving clarity and usability.